### PR TITLE
Fix formatting of Diagnostics

### DIFF
--- a/inst/shinyApps/paramGUI/app.R
+++ b/inst/shinyApps/paramGUI/app.R
@@ -558,7 +558,7 @@ server <- function(input, output, session) {
                             spec=isolate(rvs$specFitSummary),
                             spectemp=isolate(rvs$spectempFitSummary)
     )
-    output$consoleOutput <- renderPrint({print(resultToPrint)})
+    output$consoleOutput <- renderPrint({print(resultToPrint,width=100)})
   }
 
   observe({


### PR DESCRIPTION
I could reproduce the error described in #13, and it is a problem with how the diagnostics are created and a somewhat hidden feature of `print` .
The diagnostics output is created using `print`

https://github.com/glotaran/paramGUI/blob/2acd02f9042cbcf4e5406dda6699034715276d2b/inst/shinyApps/paramGUI/app.R#L561

And the problem is that `print` uses the width of the console (`getOption("width")`), which was used to start `paramGUI`, for formatting the output.

You can reproduce this error by making the RStudio Window very narrow (e.g. `getOption("width") == 30`)

This behavior can be changed by setting a fixed value for the with (100 should be enough I hope).

closes #13 