### PR TITLE
Fix for hotfix - Revert "🤔Add explict dependency on methods"

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,6 @@ License: GPL (>= 2)
 Depends:
     colorspace,
     fields,
-    methods,
     R (>= 3.0.0),
     shiny,
     shinydashboard,


### PR DESCRIPTION
This reverts commit 3c20d065b18474e1bfe3312a0e81c029830af2ad which was intended to solve one CI issues, but introduced another one. Explicitly depending is not allowed when not explicitly importing from it.